### PR TITLE
TestContainers kjører med jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,9 +213,17 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
-            <version>1.7.2</version>
+            <version>1.12.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.12.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/src/test/java/no/nav/kontantstotte/storage/s3/S3InitializerTest.java
+++ b/src/test/java/no/nav/kontantstotte/storage/s3/S3InitializerTest.java
@@ -2,25 +2,28 @@ package no.nav.kontantstotte.storage.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
+@Testcontainers
+@DisabledIfEnvironmentVariable(named="CIRCLECI", matches="true")
 public class S3InitializerTest {
 
     private static final int SIZE_MB = 20;
 
-    @Rule
+    @Container
     public LocalStackContainer localStackContainer = new LocalStackContainer().withServices(S3);
 
     private AmazonS3 s3;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         s3 = AmazonS3ClientBuilder
                 .standard()
@@ -31,7 +34,6 @@ public class S3InitializerTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named="CIRCLECI", matches="true")
     public void bucketIsCreatedwhenMissing() {
         assertThat(s3.listBuckets()).hasSize(0);
 

--- a/src/test/java/no/nav/kontantstotte/storage/s3/S3StorageTest.java
+++ b/src/test/java/no/nav/kontantstotte/storage/s3/S3StorageTest.java
@@ -3,23 +3,28 @@ package no.nav.kontantstotte.storage.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.ByteArrayInputStream;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
+@Testcontainers
+@DisabledIfEnvironmentVariable(named="CIRCLECI", matches="true")
 public class S3StorageTest {
 
-    @Rule
+    @Container
     public LocalStackContainer localStackContainer = new LocalStackContainer().withServices(S3);
 
     private S3Storage storage;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         AmazonS3 s3 = new S3StorageConfiguration().s3(
                 localStackContainer.getEndpointConfiguration(S3),
@@ -29,7 +34,6 @@ public class S3StorageTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named="CIRCLECI", matches="true")
     public void testStorage() {
         storage.put("dir", "file", new ByteArrayInputStream("asdfasdf".getBytes()));
         storage.put("dir", "file2", new ByteArrayInputStream("asdfasdf2".getBytes()));


### PR DESCRIPTION
Et par tester brakk lokalt etter at man byttet til org.junit.jupiter.api.Test ved ignorering i CircleCI. Dette fordi @Rule ikke finnes i junit5.