### PR TITLE
Setter maks filstørrelse ned til 10MB for å unngå oom-feil fra pdf-gen

### DIFF
--- a/src/main/java/no/nav/kontantstotte/storage/attachment/ImageConversionService.java
+++ b/src/main/java/no/nav/kontantstotte/storage/attachment/ImageConversionService.java
@@ -39,6 +39,7 @@ class ImageConversionService {
 
     byte[] convert(byte[] bytes, Format detectedType) {
         try {
+            log.info("Konverterer vedlegg på {} KB til PDF", bytes.length/1000);
             var request = HttpClientUtil.createRequest(TokenHelper.generateAuthorizationHeaderValueForLoggedInUser(contextHolder))
                     .header(HttpHeader.CONTENT_TYPE.asString(), detectedType.mimeType)
                     .uri(URI.create(imageToPdfEndpointBaseUrl + "v1/genpdf/image/kontantstotte"))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,7 +42,7 @@ SOKNAD_KONTANTSTOTTE_API_S3_REGION: us-east-1
 #SOKNAD_KONTANTSTOTTE_API_S3_ACCESSKEY: <Ligger i vault>
 #SOKNAD_KONTANTSTOTTE_API_S3_SECRETKEY: <Ligger i vault>
 #SOKNAD_KONTANTSTOTTE_STORAGE_ENCRYPTION_USERNAME: <Ligger i vault>
-attachment.max.size.mb: 20
+attachment.max.size.mb: 10
 
 #Unleash
 UNLEASH_API_URL: https://unleashproxy.nais.oera.no/api/


### PR DESCRIPTION
Har også lagt på logg så vi kan se tidspunktet for pdf-konvertering og vedleggstørrelse. 