### PR TITLE
Fix workflow to only deploy when push on master

### DIFF
--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -1,6 +1,9 @@
 name: Build, push, and deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
 
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/soknad-kontantstotte-api:${{ github.sha }}


### PR DESCRIPTION
The workflow deployed to prod whenever pushing on a branch, which is not proper