### PR TITLE
Bumper spring boot pga Spring4Shell

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.12</version>
     </parent>
 
     <groupId>no.nav.kontantstotte</groupId>


### PR DESCRIPTION
Det virker ikke som att vi er påvirket ennå, men fint å patche vår nav.no api
Tenker det ikke er noen direkte stress med å patche våre andre tjenester

https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

> Am I Impacted?
> These are the requirements for the specific scenario from the report:
> 
> JDK 9 or higher
> Apache Tomcat as the Servlet container
> Packaged as a traditional WAR (in contrast to a Spring Boot executable jar)
> spring-webmvc or spring-webflux dependency
> Spring Framework versions 5.3.0 to 5.3.17, 5.2.0 to 5.2.19, and older versions
> **However, the nature of the vulnerability is more general, and there may be other ways to exploit it that have not been reported yet.**